### PR TITLE
Allow nb_neurons variable at each layer

### DIFF
--- a/genome.py
+++ b/genome.py
@@ -17,7 +17,7 @@ class Genome():
 
         Args:
             all_possible_genes (dict): Parameters for the genome, includes:
-                gene_nb_neurons (list): [64, 128, 256]
+                gene_nb_neurons_i (list): [64, 128, 256]      for (i=1,...,6)
                 gene_nb_layers (list):  [1, 2, 3, 4]
                 gene_activation (list): ['relu', 'elu']
                 gene_optimizer (list):  ['rmsprop', 'adam']
@@ -39,7 +39,7 @@ class Genome():
         """
         Refesh each genome's unique hash - needs to run after any genome changes.
         """
-        genh = str(self.geneparam['nb_neurons']) + self.geneparam['activation'] \
+        genh = str(self.nb_neurons()) + self.geneparam['activation'] \
                 + str(self.geneparam['nb_layers']) + self.geneparam['optimizer']
 
         self.hash = hashlib.md5(genh.encode("UTF-8")).hexdigest()
@@ -109,11 +109,11 @@ class Genome():
 
         """
         if self.accuracy == 0.0: #don't bother retraining ones we already trained 
-            self.accuracy = train_and_score(self.geneparam, trainingset)
+            self.accuracy = train_and_score(self, trainingset)
 
     def print_genome(self):
         """Print out a genome."""
-        logging.info(self.geneparam)
+        self.print_geneparam()
         logging.info("Acc: %.2f%%" % (self.accuracy * 100))
         logging.info("UniID: %d" % self.u_ID)
         logging.info("Mom and Dad: %d %d" % (self.parents[0], self.parents[1]))
@@ -122,6 +122,24 @@ class Genome():
 
     def print_genome_ma(self):
         """Print out a genome."""
-        logging.info(self.geneparam)
+        self.print_geneparam()
         logging.info("Acc: %.2f%% UniID: %d Mom and Dad: %d %d Gen: %d" % (self.accuracy * 100, self.u_ID, self.parents[0], self.parents[1], self.generation))
-        logging.info("Hash: %s" % self.hash)    
+        logging.info("Hash: %s" % self.hash)
+
+    # print nb_neurons as single list
+    def print_geneparam(self):
+        g = self.geneparam.copy()
+        nb_neurons = self.nb_neurons()
+        for i in range(1,7):
+          g.pop('nb_neurons_' + str(i))
+        # replace individual layer numbers with single list
+        g['nb_neurons'] = nb_neurons
+        logging.info(g)
+    
+    # convert nb_neurons_i at each layer to a single list
+    def nb_neurons(self):
+      nb_neurons = [None] * 6
+      for i in range(0,6):
+        nb_neurons[i] = self.geneparam['nb_neurons_' + str(i+1)]
+
+      return nb_neurons

--- a/main.py
+++ b/main.py
@@ -171,6 +171,14 @@ def main():
             'activation': ['relu', 'elu', 'tanh', 'sigmoid', 'hard_sigmoid','softplus','linear'],
             'optimizer':  ['rmsprop', 'adam', 'sgd', 'adagrad','adadelta', 'adamax', 'nadam']
         }
+
+    # replace nb_neurons with 1 unique value for each layer
+    # 6th value reserved for dense layer
+    nb_neurons = all_possible_genes['nb_neurons']
+    for i in range(1,7):
+      all_possible_genes['nb_neurons_' + str(i)] = nb_neurons
+    # remove old value from dict
+    all_possible_genes.pop('nb_neurons')
             
     print("***Evolving for %d generations with population size = %d***" % (generations, population))
 

--- a/train.py
+++ b/train.py
@@ -188,7 +188,7 @@ def compile_model_mlp(geneparam, nb_classes, input_shape):
 
     return model
 
-def compile_model_cnn(geneparam, nb_classes, input_shape):
+def compile_model_cnn(genome, nb_classes, input_shape):
     """Compile a sequential model.
 
     Args:
@@ -199,12 +199,12 @@ def compile_model_cnn(geneparam, nb_classes, input_shape):
 
     """
     # Get our network parameters.
-    nb_layers  = geneparam['nb_layers' ]
-    nb_neurons = geneparam['nb_neurons']
-    activation = geneparam['activation']
-    optimizer  = geneparam['optimizer' ]
+    nb_layers  = genome.geneparam['nb_layers' ]
+    nb_neurons = genome.nb_neurons()
+    activation = genome.geneparam['activation']
+    optimizer  = genome.geneparam['optimizer' ]
 
-    logging.info("Architecture:%d,%s,%s,%d" % (nb_neurons, activation, optimizer, nb_layers))
+    logging.info("Architecture:%s,%s,%s,%d" % (str(nb_neurons), activation, optimizer, nb_layers))
 
     model = Sequential()
 
@@ -212,9 +212,9 @@ def compile_model_cnn(geneparam, nb_classes, input_shape):
     for i in range(0,nb_layers):
         # Need input shape for first layer.
         if i == 0:
-            model.add(Conv2D(nb_neurons, kernel_size = (3, 3), activation = activation, padding='same', input_shape = input_shape))
+            model.add(Conv2D(nb_neurons[i], kernel_size = (3, 3), activation = activation, padding='same', input_shape = input_shape))
         else:
-            model.add(Conv2D(nb_neurons, kernel_size = (3, 3), activation = activation))
+            model.add(Conv2D(nb_neurons[i], kernel_size = (3, 3), activation = activation))
         
         if i < 2: #otherwise we hit zero
             model.add(MaxPooling2D(pool_size=(2, 2)))
@@ -222,7 +222,8 @@ def compile_model_cnn(geneparam, nb_classes, input_shape):
         model.add(Dropout(0.2))
 
     model.add(Flatten())
-    model.add(Dense(nb_neurons, activation = activation))
+    # always use last nb_neurons value for dense layer
+    model.add(Dense(nb_neurons[5], activation = activation))
     model.add(Dropout(0.5))
     model.add(Dense(nb_classes, activation = 'softmax'))
 
@@ -242,7 +243,7 @@ class LossHistory(Callback):
     def on_batch_end(self, batch, logs={}):
         self.losses.append(logs.get('loss'))
 
-def train_and_score(geneparam, dataset):
+def train_and_score(genome, dataset):
     """Train the model, return test loss.
 
     Args:
@@ -266,11 +267,11 @@ def train_and_score(geneparam, dataset):
     if dataset   == 'cifar10_mlp':
         model = compile_model_mlp(geneparam, nb_classes, input_shape)
     elif dataset == 'cifar10_cnn':
-        model = compile_model_cnn(geneparam, nb_classes, input_shape)
+        model = compile_model_cnn(genome, nb_classes, input_shape)
     elif dataset == 'mnist_mlp':
         model = compile_model_mlp(geneparam, nb_classes, input_shape)
     elif dataset == 'mnist_cnn':
-        model = compile_model_cnn(geneparam, nb_classes, input_shape)
+        model = compile_model_cnn(geneome, nb_classes, input_shape)
 
     history = LossHistory()
 


### PR DESCRIPTION
It would be useful to allow a different number of filters at each layer, since CNN's usually have this structure. An ideal combination of number of filters at each layer is then bred over time, just as with the other parameters

## Implementation 
The single `nb_neurons` gene is replaced with 6 separate genes, `nb_neurons_1`, `nb_neurons_2`, etc.
The first 5 represent the number of neurons at each potential convolution layer.
The 6th is always held for the number of neurons in the Dense layer. 
Each layer shares the same possible values as the original `nb_neurons` gene.

The  separate genes can be accessed as a single list by calling `genome.nb_neurons()`, useful when printing a genome. 

#
This is a bit hacky right now, it's meant mostly as a proof of concept.
For a cleaner implementation, the structure of `genome` and `geneparam` would have to be changed.
I've tested it with `CIFAR_10` and reached ~60% within a couple generations.

## Possible changes
- Having the `nb_neurons` array as a single gene, i.e. the whole list is one attribute that can be passed on together
(less parameters, but may ignore potential good combinations of different layer numbers)
- Not allowing shorter networks to pass on `nb_neurons` values for later layers
ex: EVERY genome has values for all 5 layers, but many networks do not use all 5 layers, so it may make sense to not allow genomes to pass on `nb_neurons_i` values for `i > nb_layers`